### PR TITLE
Remove completion restrictions

### DIFF
--- a/Syntaxes/SCSS.sublime-settings
+++ b/Syntaxes/SCSS.sublime-settings
@@ -4,7 +4,7 @@
 
     // Controls what scopes default completions will be provided in.
     // Can be a list of strings which are joined before matching.
-    "default_completions_selector": "source.scss - meta.selector",
+    "default_completions_selector": "source.scss",
 
     // Default separators except `-`
     "word_separators": "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?",

--- a/Syntaxes/Sass.sublime-settings
+++ b/Syntaxes/Sass.sublime-settings
@@ -4,7 +4,7 @@
 
     // Controls what scopes default completions will be provided in.
     // Can be a list of strings which are joined before matching.
-    "default_completions_selector": "source.sass - meta.selector",
+    "default_completions_selector": "source.sass",
 
     // Default separators except `-`
     "word_separators": "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?",

--- a/plugins/completions/provider.py
+++ b/plugins/completions/provider.py
@@ -234,10 +234,8 @@ class ScssCompletions(BaseCompletionsProvider, sublime_plugin.EventListener):
             items = self.complete_function_argument(view, prefix, pt)
         elif view.match_selector(pt - 1, "meta.property-value, punctuation.separator.key-value"):
             items = self.complete_property_value(view, prefix, pt, True)
-        elif view.match_selector(pt - 1, "meta.property-name, meta.property-list - meta.selector"):
-            items = self.complete_property_name(view, prefix, pt, True)
         else:
-            items = None
+            items = self.complete_property_name(view, prefix, pt, True)
 
         if items:
             return sublime.CompletionList(items)


### PR DESCRIPTION
Resolves #107

Suggest properties also within `meta.selector` as this is the most likely scope in front of a nested selector, if a property is not yet terminated by semi-colon.